### PR TITLE
🐛 fix: 일정추가 시 올바르게 중복체크하도록

### DIFF
--- a/src/api/http/httpRequest.ts
+++ b/src/api/http/httpRequest.ts
@@ -8,7 +8,7 @@ export class HttpRequest {
     this.service = service;
   }
 
-  get<T>(url: string) {
+  get<T>(url: ApiUrlType) {
     return this.service.get<T>(url).then((res) => res);
   }
 

--- a/src/api/models/useScheduleModel.ts
+++ b/src/api/models/useScheduleModel.ts
@@ -20,24 +20,6 @@ const useScheduleModel = () => {
     }
   };
 
-  const checkSavedScheduleData = async (day: string, startTime: number) => {
-    try {
-      const scheduleResponse: AxiosResponse<ScheduleInterface[]> =
-        await apiRequest.get<ScheduleInterface[]>(
-          `${ApiUrlEnum.SCHEDULE}?day=${day}&startTime=${startTime}`
-        );
-      const data = scheduleResponse.data;
-      const msg = data.length > 0 ? '중복 일정이 있습니다.' : '';
-      const result = data.length > 0 ? false : true;
-      return { msg: msg, result: result, data: data };
-    } catch (error) {
-      return {
-        msg: '오류가 발생하였습니다. 관리자에게 문의 하세요.',
-        result: false,
-      };
-    }
-  };
-
   const createtSchedule = async <T>(data: T) => {
     try {
       await apiRequest.post<T>(ApiUrlEnum.SCHEDULE, data);
@@ -59,7 +41,6 @@ const useScheduleModel = () => {
     getScheduleData,
     createtSchedule,
     deleteSchedule,
-    checkSavedScheduleData,
   };
 };
 

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -1,0 +1,1 @@
+export const MSG_DUPLICATION_SCHEDULE = '중복된 일정이 있습니다.';

--- a/src/pages/ScheduleAddPage.tsx
+++ b/src/pages/ScheduleAddPage.tsx
@@ -8,6 +8,8 @@ import styled from 'styled-components';
 import { theme } from '@/styles/theme';
 import useScheduleModel from '@/api/models/useScheduleModel';
 import days from '@/utils/weekDays';
+import { MSG_DUPLICATION_SCHEDULE } from '@/constants/message';
+import { adjustHourByMinute } from '@/utils/formatTime';
 
 const buttonBorder = `1px solid ${theme.color.border.lightgray}`;
 const fontColor = `${theme.color.font.lightgray}`;
@@ -22,10 +24,7 @@ const ScheduleAddPage = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const fetchData = async () => {
-      getScheduleData();
-    };
-    fetchData();
+    getScheduleData();
   }, []);
 
   const handleClickedDaysButton = (
@@ -59,7 +58,11 @@ const ScheduleAddPage = () => {
   const findSameDayAndTime = (day: string, selectedTime: number) => {
     return schedules
       .filter((schedule) => schedule.day === day)
-      .find((schedule) => schedule.startTime === selectedTime);
+      .find(
+        (schedule) =>
+          selectedTime >= schedule.startTime &&
+          selectedTime < adjustHourByMinute(schedule.startTime + 40)
+      );
   };
 
   const checkDuplication = (selectedDays: string[], selectedTime: number) => {
@@ -81,7 +84,7 @@ const ScheduleAddPage = () => {
 
     if (selectedDays.length === 0) return;
     if (checkDuplication(selectedDays as string[], selectedTime)) {
-      alert('중복된 일정이 있습니다.');
+      alert(MSG_DUPLICATION_SCHEDULE);
       return;
     }
 

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,8 +1,12 @@
 import pad2Digit from './pad2Digit';
 import { periods } from './periods';
 
+export const adjustHourByMinute = (time: number) => {
+  return time % 100 >= 60 ? (time += 40) : time;
+};
+
 export const getPrettyTime = (time: number) => {
-  if (time % 100 >= 60) time += 40;
+  time = adjustHourByMinute(time);
   const isNight = time >= 1200 ? true : false;
   if (time >= 1300) time -= 12 * 100;
 


### PR DESCRIPTION
## 😲 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
<!-- [] 안에 소문자 엑스(x)를 넣으면 체크표시가 활성화됩니다! ex) [x] -->
- [ ] 기능 추가
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

## 😎 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
* 일정 추가 시 중복 일정 확인 로직을 변경 하였습니다.
   * 이전: 2개 이상의 요일을 선택 시 2번 API 요청하여 중복을 확인 합니다. 매 요일 확인 시 마다 중복과 추가 API를 요청하게 하여 이후 중복 요일이 있으면 이미 생성 된 일정을 돌릴 수 없었음
   * 개선: 일정추가 페이지 접속 시 저장된 일정을 서버로 부터 가져옴(개인이 사용하여 실시간 데이터 변동 없음) -> 일정 추가 버튼을 누를 때, 이미 가져온 데이터와 비교하여 중복을 체크 함.

## 🥳 성장 포인트 (기능 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
* 해당 웹 페이지의 사용성을 예상하여 서버 부하를 줄이고 중복 체크 하는 방향으로 구현하였습니다.

## 🤔 기타 질문 및 특이 사항
<!-- @@ 부분 코드가 너무 복잡한 것 같은데 더 줄일 수 있는 방법이 없을까요? 같은 고민되는 내용을 마구 공유해주세요! -->
